### PR TITLE
Develop auto job flow management & fix memory leak bug & add job system unit test

### DIFF
--- a/Engine/Engine/EngineTest.cpp
+++ b/Engine/Engine/EngineTest.cpp
@@ -1,3 +1,4 @@
+#include <crtdbg.h>
 #include "GameEngine.h"
 
 using std::to_wstring;
@@ -166,7 +167,8 @@ int WINAPI wWinMain(
     object.~SmartPtr();
     /**/
 
-
+    //#define _CRTDBG_MAP_ALLOC
+    _CrtSetReportMode(_CRT_WARN, _CRTDBG_MODE_DEBUG);
     _CrtDumpMemoryLeaks();
 
     return 0;

--- a/Engine/JobSys/HashedString.cpp
+++ b/Engine/JobSys/HashedString.cpp
@@ -47,7 +47,7 @@ HashedString& HashedString::operator=(const HashedString& other)
 #if defined(_DEBUG)
 	if (str)
 		free(str);
-	this->str = other.str;
+	this->str = _strdup(other.str);
 #endif
 
 	return *this;

--- a/Engine/JobSys/JobQueue.cpp
+++ b/Engine/JobSys/JobQueue.cpp
@@ -165,6 +165,12 @@ bool JobQueue::HasJobs() const
 }
 
 
+void JobQueue::WakeRunners()
+{
+	WakeAllConditionVariable(&queueNotEmpty);
+}
+
+
 string JobQueue::GetName() const
 {
 	return queueName;

--- a/Engine/JobSys/JobQueue.h
+++ b/Engine/JobSys/JobQueue.h
@@ -121,6 +121,8 @@ public:
 	bool IsStopped() const;
 	bool HasJobs() const;
 
+	void WakeRunners();
+
 	std::string GetName() const;
 };
 

--- a/Engine/JobSys/JobSys.cpp
+++ b/Engine/JobSys/JobSys.cpp
@@ -12,8 +12,6 @@ using std::map;
 using namespace JobSys;
 
 
-
-
 void JobSystem::JobFlowControl()
 {
 	do
@@ -24,38 +22,39 @@ void JobSystem::JobFlowControl()
 			JobQueueManager* manager = iter->second;
 			if (manager != nullptr && manager->jobFlowManager.isAuto == true)
 			{
-				/* If the amount of waiting jobs in current job queue is larger then overflow threshold.
-				 * Case 1: the overflow flag is TURE, add one more job runner to the queue and reset the
-				 *		   overflow flag.
-				 * Case 2: the overflow flat is FALSE, set the flag to TRUE. */
-				if (manager->jobStatus.JobsLeft() > JobFlowManager::threshold)
+				/* If the amount of waiting jobs in current job queue is more than overflow threshold.
+				 * Case 1: the "isTooMany" flag is TURE, add one more job runner to the queue and reset
+				 *		   the "isTooMany" flag.
+				 * Case 2: the "isTooMany" flat is FALSE, set the flag to TRUE. */
+				if (manager->jobStatus.JobsLeft() > JobFlowManager::upperTHR)
 				{
-					if (manager->jobFlowManager.overflowFlag == true)
+					if (manager->jobFlowManager.isTooMany == true)
 					{
 						AddRunnerToQueue(manager);
-						manager->jobFlowManager.overflowFlag = false;
+						manager->jobFlowManager.isTooMany = false;
 					}
 					else
-						manager->jobFlowManager.overflowFlag = true;
+						manager->jobFlowManager.isTooMany = true;
 				}
-				/* If the amount of waiting jobs in current job queue is less then zero.,
-				 * Case 1: the idle flag is TRUE, remove one job runner form the queue and reset the
-				 *		   flag.
-				 * Case 2: the idle flag is FALSE, set the flag to TRUE. */
-				else if (manager->jobStatus.JobsLeft() == 0)
+				/* If the total amount of jobs in current job queue is more than the number of job 
+				 * runners in current job queue.
+				 * Case 1: the "isTooFew" flag is TRUE, remove one job runner form the queue and reset 
+				 *		   the "isTooFew" flag.
+				 * Case 2: the "isTooFew" flag is FALSE, set the flag to TRUE. */
+				else if (manager->jobStatus.JobsLeft() < manager->jobRunnerList.size())
 				{
-					if (manager->jobFlowManager.idleFlag == true)
+					if (manager->jobFlowManager.isTooFew == true)
 					{
 						RemoveRunnerFromQueue(manager);
-						manager->jobFlowManager.idleFlag = false;
+						manager->jobFlowManager.isTooFew = false;
 					}
 					else
-						manager->jobFlowManager.idleFlag = true;
+						manager->jobFlowManager.isTooFew = true;
 				}
 				else
 				{
-					manager->jobFlowManager.overflowFlag = false;
-					manager->jobFlowManager.idleFlag = false;
+					manager->jobFlowManager.isTooMany = false;
+					manager->jobFlowManager.isTooFew = false;
 				}
 			}
 

--- a/Engine/JobSys/JobSys.h
+++ b/Engine/JobSys/JobSys.h
@@ -1,5 +1,6 @@
 #pragma once
 #include <map>
+#include <vector>
 #include <iostream>
 #include <Windows.h>
 #include <processthreadsapi.h>
@@ -10,18 +11,17 @@
 #include "Debugger.h"
 
 
-
 namespace Engine
 {
 
 struct JobFlowManager
 {
 	bool isAuto;
-	bool overflowFlag = false;
-	bool idleFlag = false;
+	bool isTooMany = false;
+	bool isTooFew  = false;
 
 	static const DWORD interval = 100;
-	static const uint32_t threshold = 25;
+	static const uint32_t upperTHR = 25;
 
 	JobFlowManager(bool isAuto) : isAuto(isAuto)
 	{}
@@ -199,8 +199,7 @@ inline void JobSystemUnitTest()
 			{
 				for (std::vector<JobSysTester*>::iterator iter = newTester->begin(); iter != newTester->end(); iter++)
 				{
-					//Engine::Debugger::DEBUG_PRINT("Moving Obj: %s \n", (*iter)->name.c_str());
-					DEBUG_PRINT("Moving Obj \n");
+					DEBUG_PRINT("Moving Obj %s \n", (*iter)->name.c_str());
 					allTester->push_back((*iter));
 					Sleep(10);
 				}
@@ -236,11 +235,12 @@ inline void JobSystemUnitTest()
 			delete (*iter);
 		}
 
-		delete allTester, newTester, mutex;
+		delete allTester;
+		delete newTester;
+		delete mutex;
 		bool success = jobSystem.RemoveQueue(queueName);
 		assert(success == true);
 	}
-
 
 	/* Test 3: Test dynamic job flow controller. */
 	DEBUG_PRINT("\n\nStarting Test 3 \n");
@@ -267,8 +267,6 @@ inline void JobSystemUnitTest()
 
 		jobSystem.GetQueue(queueName)->jobStatus.WaitForZeroJobsLeft();
 	}
-
-
 
 	jobSystem.RequestStop();
 }


### PR DESCRIPTION
This pull request develops an auto job flow management mechanism for the job system. The job system will initialize a default job queue the run the job flow management routine. The routine will periodically check all existing job queues in the system. If the amount of waiting jobs in the queue is more than a pre-set threshold, the routine will add a job runner to the job queue. If the amount of waiting jobs is less than the number of job runners, the routine will remove a job runner.

This pull request also fixes all memory leak issues in the job system and develops three unit tests for the job system. The unit tests test ordinary functionality of the job system, synchronization components (e,g. mutex, scoped lock), and job flow management. 