### PR TITLE
Optimize Vector & Matrix

### DIFF
--- a/Engine/DataType/Math/Vector.h
+++ b/Engine/DataType/Math/Vector.h
@@ -3,9 +3,6 @@
 #include "Mathf.h"
 
 
-/* TODO: Using array pointer instead of array to store data. This can improve the performance of construction */
-
-
 namespace Engine
 {
 /* Forwared declaration */
@@ -40,7 +37,7 @@ public:
 		memcpy_s(val, 2*sizeof(T), other.val, 2*sizeof(T));
 	}
 
-	inline Vector2(Vector2<T>&& other)
+	inline Vector2(Vector2<T>&& other) noexcept
 	{
 		this->val = other.val;
 		other.val = nullptr;
@@ -235,7 +232,7 @@ public:
 		memcpy_s(val, 3*sizeof(T), other.val, 3*sizeof(T));
 	}
 
-	inline Vector3(Vector3<T>&& other)
+	inline Vector3(Vector3<T>&& other) noexcept
 	{
 		this->val = other.val;
 		other.val = nullptr;
@@ -456,7 +453,7 @@ public:
 		memcpy_s(val, 4*sizeof(T), other.val, 4*sizeof(T));
 	}
 
-	inline Vector4(Vector4<T>&& other)
+	inline Vector4(Vector4<T>&& other) noexcept
 	{
 		this->val = other.val;
 		other.val = nullptr;

--- a/Engine/DataType/Math/Vector.h
+++ b/Engine/DataType/Math/Vector.h
@@ -23,18 +23,33 @@ template <typename T>
 class Vector2
 {
 private:
-	T val[2] = { static_cast<T>(0), static_cast<T>(0) };
+	/* A pointer to a 1x2 array */
+	T* val = new T[2] { static_cast<T>(0), static_cast<T>(0) };
 
 public:
 	/* Constructor */
 	inline Vector2() = default;
-	inline Vector2(T x, T y)
+
+	inline Vector2(T x, T y) : val(new T[2])
 	{
 		val[0] = x; val[1] = y;
 	}
-	inline Vector2(const Vector2<T>& other)
+
+	inline Vector2(const Vector2<T>& other) : val(new T[2])
 	{
-		val[0] = other[0]; val[1] = other[1];
+		memcpy_s(val, 2*sizeof(T), other.val, 2*sizeof(T));
+	}
+
+	inline Vector2(Vector2<T>&& other)
+	{
+		this->val = other.val;
+		other.val = nullptr;
+	}
+
+	inline ~Vector2()
+	{
+		if (val != nullptr)
+			delete[] val;
 	}
 
 	/* @brief Convert this instance to a new Vector2 with type "U" */
@@ -142,7 +157,7 @@ public:
 	/* Assignment operators */
 	inline Vector2<T>& operator= (const Vector2<T>& other)
 	{
-		val[0] = other[0]; val[1] = other[1];
+		memcpy_s(val, 2*sizeof(T), other.val, 2*sizeof(T));
 		return *this;
 	}
 
@@ -167,10 +182,12 @@ public:
 	/* Indexing */
 	inline T& operator[] (int idx)
 	{
+		assert(idx >= 0 && idx <= 1);
 		return val[idx];
 	}
 	inline const T& operator[] (int idx) const
 	{
+		assert(idx >= 0 && idx <= 1);
 		return val[idx];
 	}
 
@@ -201,18 +218,33 @@ template <typename T>
 class Vector3
 {
 private:
-	T val[3] = { static_cast<T>(0), static_cast<T>(0), static_cast<T>(0) };
+	/* A pointer to a 1x3 array */
+	T* val = new T[3] { static_cast<T>(0), static_cast<T>(0), static_cast<T>(0) };
 
 public:
 	/* Constructor */
 	inline Vector3() = default;
-	inline Vector3(T x, T y, T z)
+
+	inline Vector3(T x, T y, T z) : val(new T[3])
 	{
 		val[0] = x; val[1] = y; val[2] = z;
 	}
-	inline Vector3(const Vector3<T>& other)
+
+	inline Vector3(const Vector3<T>& other) : val(new T[3])
 	{
-		val[0] = other[0]; val[1] = other[1]; val[2] = other[2];
+		memcpy_s(val, 3*sizeof(T), other.val, 3*sizeof(T));
+	}
+
+	inline Vector3(Vector3<T>&& other)
+	{
+		this->val = other.val;
+		other.val = nullptr;
+	}
+
+	inline ~Vector3()
+	{
+		if (val != nullptr)
+			delete[] val;
 	}
 
 	/* @brief Convert this instance to a new Vector3 with type "U" */
@@ -339,7 +371,7 @@ public:
 	/* Assignment operators */
 	inline Vector3<T>& operator= (const Vector3<T>& other)
 	{
-		val[0] = other[0]; val[1] = other[1]; val[2] = other[2];
+		memcpy_s(val, 3*sizeof(T), other.val, 3*sizeof(T));
 		return *this;
 	}
 
@@ -366,10 +398,12 @@ public:
 	/* Indexing */
 	inline T& operator[] (int idx)
 	{
+		assert(idx >= 0 && idx <= 2);
 		return val[idx];
 	}
 	inline const T& operator[] (int idx) const
 	{
+		assert(idx >= 0 && idx <= 2);
 		return val[idx];
 	}
 
@@ -404,20 +438,34 @@ template<typename T>
 class Vector4
 {
 private:
-	T val[4] = {
-		static_cast<T>(0), static_cast<T>(0), 
+	/* A pointer to a 1x4 array */
+	T* val = new T[4]{
+		static_cast<T>(0), static_cast<T>(0),
 		static_cast<T>(0), static_cast<T>(0) };
 
 public:
 	inline Vector4() = default;
-	inline Vector4(T w, T x, T y, T z)
+
+	inline Vector4(T w, T x, T y, T z) : val(new T[4])
 	{
 		val[0] = w, val[1] = x, val[2] = y, val[3] = z;
 	}
-	inline Vector4(const Vector4<T>& other)
+
+	inline Vector4(const Vector4<T>& other) : val(new T[4])
 	{
-		val[0] = other[0], val[1] = other[1];
-		val[2] = other[2], val[3] = other[3];
+		memcpy_s(val, 4*sizeof(T), other.val, 4*sizeof(T));
+	}
+
+	inline Vector4(Vector4<T>&& other)
+	{
+		this->val = other.val;
+		other.val = nullptr;
+	}
+
+	inline ~Vector4()
+	{
+		if (val != nullptr)
+			delete[] val;
 	}
 
 	/* @brief Convert this instance to a new Vector4 with type "U" */
@@ -432,14 +480,23 @@ public:
 	/* Indexing */
 	inline T& operator[] (int idx)
 	{
+		assert(idx >= 0 && idx <= 3);
 		return val[idx];
 	}
 	inline const T& operator[] (int idx) const
 	{
+		assert(idx >= 0 && idx <= 3);
 		return val[idx];
 	}
 
 	/* Assignment */
+	inline Vector4<T>& operator= (const Vector4<T>& other)
+	{
+		memcpy_s(val, 4*sizeof(T), other.val, 4*sizeof(T));
+		return *this;
+	}
+
+	/* Comaprison */
 	inline bool operator== (const Vector4<T>& other) const
 	{
 		return (
@@ -448,7 +505,6 @@ public:
 			AreEqual(static_cast<float>(val[2]), static_cast<float>(other[2])) == true &&
 			AreEqual(static_cast<float>(val[3]), static_cast<float>(other[3])) == true);
 	}
-
 
 	inline Vector4<T> operator* (const Vector4<T>& other) const
 	{
@@ -526,8 +582,6 @@ inline Vector3<T> Cross(const Vector3<T>& lhs, const Vector3<T>& rhs)
 
 #if defined(_DEBUG)
 
-#include <cassert>
-
 inline void Vector2UnitTest()
 {
 	Vector2<int> case0 = Vector2<int>(4, 3);
@@ -539,6 +593,13 @@ inline void Vector2UnitTest()
 	Vector2<float> temp1;
 	Vector2<double> temp2;
 	float val0;
+
+
+	assert(AreEqual(temp1[0], 0.0f) && AreEqual(temp1[1], 0.0f));
+	assert(AreEqual(case1[0], 4.4f) && AreEqual(case1[1], 3.3f));
+
+	Vector2<float> temp4 = case1;
+	assert(AreEqual(temp4[0], 4.4f) && AreEqual(temp4[1], 3.3f));
 
 	temp0 = case1.ConvertTo<int>();
 	assert(temp0[0] == 4 && temp0[1] == 3);
@@ -613,6 +674,13 @@ inline void Vector3UnitTest()
 	Vector3<float> temp1;
 	Vector3<double> temp2;
 	float val0;
+
+
+	assert(AreEqual(temp1[0], 0.0f) && AreEqual(temp1[1], 0.0f) && AreEqual(temp1[2], 0.0f));
+	assert(AreEqual(case1[0], 3.3f) && AreEqual(case1[1], 4.4f) && AreEqual(case1[2], 5.5f));
+
+	Vector3<float> temp4 = case1;
+	assert(AreEqual(temp4[0], 3.3f) && AreEqual(temp4[1], 4.4f) && AreEqual(temp4[2], 5.5f));
 
 	temp0 = case1.ConvertTo<int>();
 	assert(temp0[0] == 3 && temp0[1] == 4 && temp0[2] == 5);

--- a/Engine/JobSys/JobSys.h
+++ b/Engine/JobSys/JobSys.h
@@ -263,7 +263,7 @@ inline void JobSystemUnitTest()
 			Sleep(150);
 		};
 
-		JobSys::HashedString queueName = jobSystem.CreateQueue("JobFlowController", 1, true);
+		JobSys::HashedString queueName = jobSystem.CreateQueue("WorkloadTester", 1, true);
 
 		
 		for (int i = 0; i < 3; i++)

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ The game engine implements object instances monitor algorithm and runtime garbag
 
 这是一款基于C/C++开发的，Windows桌面平台的2D游戏引擎。  
 
-该项目实现了游戏引擎的物理系统，计时系统，动态内存分配系统。游戏引擎的的内存分配系统使用了本人在另一个个人项目中开发的[内存分配器](https://github.com/WaterFriend/MemoryAllocator) 。该项目除了必要的Window平台库（如WIndows.h），图形渲染库（如OpenCV）和C/C++基础库（如C Runtime Library 和 C++ Standard Library）外没有依赖额外的外部库。
+该项目实现了游戏引擎的物理系统，计时系统，动态内存分配系统。游戏引擎的的内存分配系统使用了本人在另一个个人项目中开发的[内存分配器](https://github.com/WaterFriend/MemoryAllocator) 。该项目除了必要的Window平台库（如WIndows.h），图形渲染库（如OpenGL）和C/C++基础库（如C Runtime Library 和 C++ Standard Library）外没有依赖额外的外部库。
 
 + 使用了C++多态，C++模板实现了智能指针，并以此实现了对象引用的实时监控和运行时内存的动态回收。
 + 使用Windows API 实现了多线程任务队列系统，该系统支持根据阻塞的任务数量动态增删任务执行线程，依次优化任务队列的执行性能。


### PR DESCRIPTION
This pull request changes the way to store data in Vector and Matrix classes from using a one/two-dimensional array to using a pointer to the array.

Using a single array to store the data is easy to maintain. However, in the scenario of constructing a new instance from the right reference, (e.g. returning an instance from a function or creating a new instance from the return of a function), copy constructor will be involved. Copy constructor will deep copy all the data to the new instance, which significantly slows down the performance.

Using a pointer to the array to store the data allows Vector and Matrix classes to create new instances from the right reference using move constructor. Instead of deep copying all data, move constructor simply copy the pointer to the new instance, and set the pointer in the right reference to NULL. The overhead of deep copy is avoided 